### PR TITLE
Typ A Kouhyouteki translation

### DIFF
--- a/data/kr/items.json
+++ b/data/kr/items.json
@@ -300,6 +300,7 @@
   "Ju87C改二(KMX搭載機)": "Ju 87C 개2 (KMX탑재기)",
   "S9 Osprey": "S9 오스프리",
   "Bofors 15.2cm連装砲 Model 1930": "Bofors 15.2cm 연장포 Model 1930",
+  "甲標的 甲型": "갑표적 갑형",
   
   "5inch単装砲": "5inch 단장포",
   "5inch連装砲": "5inch 연장포",


### PR DESCRIPTION
Kouhyouteki seems to change its name to Type A Kouhyouteki (In Japanese).

갑표적이 갑표적 갑형으로 이름이 바뀌어서 기존 번역이 적용되지 않는것으로 보임.
갑표적 갑형 번역 따로 추가했음. 기존 번역도 유지.